### PR TITLE
🐛해시태그 모델에 맞게 로직 수정

### DIFF
--- a/profiles/urls.py
+++ b/profiles/urls.py
@@ -1,13 +1,20 @@
+from django.urls import path
+
 from .views import *
 from rest_framework.routers import DefaultRouter
 
 router = DefaultRouter()
 router.register('profile', ProfileView)
 router.register('study', StudyView)
-router.register('hashtag', HashtagView)
 router.register('skill', SkillView)
 router.register('project', ProjectView)
 router.register('career', CareerView)
 router.register('follow', FollowView)
 
 urlpatterns = router.get_urls()
+urlpatterns += [
+    path('hashtag/', HashtagView.as_view({'post': 'create'})),
+    path('hashtag/get_hashtag/<str:user>/', HashtagView.as_view({'get': 'get_hashtag'})),
+    path('hashtag/get_user/<str:hashtag>/', HashtagView.as_view({'get': 'get_user'})),
+    path('hashtag/<str:hashtag>/', HashtagView.as_view({'delete': 'destroy'})),
+]

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -22,6 +22,34 @@ class HashtagView(ModelViewSet):
     queryset = Hashtag.objects.all()
     serializer_class = HashtagSerializer
 
+    @action(detail=True, methods=['get'])
+    def get_hashtag(self, request, user):
+        queryset = self.queryset.filter(profile=user)
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(data=serializer.data, status=status.HTTP_200_OK)
+
+    @action(detail=True, methods=['get'])
+    def get_user(self, request, hashtag):
+        queryset = self.queryset.filter(hashtag_name=hashtag)
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(data=serializer.data, status=status.HTTP_200_OK)
+
+    @action(detail=True, methods=['delete'])
+    def destroy(self, request, hashtag):
+        queryset = self.queryset.get(hashtag_name=hashtag)
+        queryset.profile.remove(Profile.objects.get(user=request.user))
+        if not queryset.profile:
+            self.perform_destroy(queryset)
+        return Response(status=status.HTTP_200_OK)
+
+    def create(self, request, *args, **kwargs):
+        try:
+            queryset = self.queryset.get(hashtag_name=request.data['hashtag_name'])
+            queryset.profile.add(Profile.objects.get(user=request.user))
+            return Response(status=status.HTTP_201_CREATED)
+        except Exception:
+            return super().create(request, *args, **kwargs)
+
 
 class SkillView(ModelViewSet):
     queryset = Skill.objects.all()


### PR DESCRIPTION
해시태그 모델은 many-to-many 모델로, 해시태그 이름이 pk고 그에 해당하는 유저가 리스트로 존재함
따라서 원래 메소드론 원하는대로 삭제, 수정, 추가가 불가능하여 알맞게 수정함

- get_hashtag: 주소에 유저를 추가하면 해당 유저가 가진 해시태그들 반환
- get_usr: 주소에 해시태그를 추가하면 해당 해시태그를 가진 유저들 반환
- destroy: 로그인한 유저를 기준으로 해당하는 해시태그 삭제 - 해시태그 모델에서 해당 유저를 없앰
- create: 로그인한 유저를 기준으로 해당하는 해시태그 추가 - 이미 해당 해시태그 존재시 유저를 유저 리스트에 추가

리뷰 부탁드립니다