### PR TITLE
🐛해시태그 재생성 안되는 에러 수정

### DIFF
--- a/profiles/views.py
+++ b/profiles/views.py
@@ -43,7 +43,9 @@ class HashtagView(ModelViewSet):
     def destroy(self, request, hashtag):
         queryset = self.queryset.get(hashtag_name=hashtag)
         queryset.profile.remove(Profile.objects.get(user=request.user))
-        if not queryset.profile:
+        try:
+            queryset.profile.get()
+        except Exception:
             self.perform_destroy(queryset)
         return Response(status=status.HTTP_200_OK)
 


### PR DESCRIPTION
기존은 if not queryset.profile: 
였는데 profile 자체가 manytomany field라서 엉뚱한 게 반환되더라구여...
(실제 반환값: <django.db.models.fields.related_descriptors.create_forward_many_to_many_manager.<locals>.ManyRelatedManager object at 0x102d999c0>)
profile이 비어있으면 get()이 실행 안되니까 try except로 처리했어요
확인 부탁~~!